### PR TITLE
 Make the bike electric work with any city with a GBFS feed! 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 scripts/data/
+bundle.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-registry=http://npm-proxy.spotify.net/npm/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Is there an electric Citi Bike near you?
 
-This is the project that powers the website: [https://www.i-want-to-ride-an-electric-citi.bike](https://www.i-want-to-ride-an-electric-citi.bike)
+This is the project that powers the website: [https://www.i-want-to-ride-an-electric-citi.bike](https://www.i-want-to-ride-an-electric-citi.bike) and https://the-cabi-electric.glitch.me/
 
 Citi Bike operates the bike share in NYC. They've recently introduced electric bikes (⚡️🚲!)  and they are elusive as heck. After a weekend of not being able to find one, I made this app.
 
@@ -10,9 +10,26 @@ Made by [Aliza Aufrichtig](https://www.twitter.com/alizauf).
 
 Clone this repo, then run:
 
-`npm install`
-`npm run dev`
+```
+npm install
+npm run dev
+```
 
 The app is written using [Svelte](https://github.com/sveltejs/svelte), [Leaflet](https://leafletjs.com/), and [Citi Bike's Real Time Data API](https://www.citibikenyc.com/system-data). It is not affiliated with, approved by, endorsed by, or sponsored by Citi Bike. 
 
 ## I hope you find an ⚡️🚲!
+
+## Want to run it for another city?
+[Daniel Schep](https://www.twitter.com/schep_) updated the bike electric to work more easily with any
+bikeshare operator with electric bikes that provides [GBFS](https://github.com/NABSA/gbfs) feeds.
+
+See `config/nyc.js` and `config/dc.js` for examples of how to configure the bike electric for different cities.
+Create your own config at `config/CITYNAME.js` and run locally with: 
+```
+npm install
+CONFIG=./config/CITYNAME.js npm run dev
+```
+And compile a production version with:
+```
+CONFIG=./config/CITYNAME.js npm run build
+```

--- a/config/dc.js
+++ b/config/dc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  STATION_STATUS_GBFS: "'https://gbfs.capitalbikeshare.com/gbfs/en/station_status.json'",
+  STATION_INFORMATION_GBFS: "'https://gbfs.capitalbikeshare.com/gbfs/en/station_information.json'",
+  MAP_CENTER: "[38.91, -77.04]",
+  MAP_ZOOM: 13,
+  CITY_NAME: 'NYC',
+  BIKESHARE_NAME: 'Capital Bikeshare',
+  BIKESHARE_NAME_PLURAL: 'Capital Bikeshares',
+  BIKESHARE_DATA_URL: 'https://www.capitalbikeshare.com/system-data',
+  AUTHOR: "<a href='https://twitter.com/alizauf'>Aliza Aufrichtig</a> & <a href='https://twitter.com/schep_'>Daniel Schep</a>",
+}

--- a/config/dc.js
+++ b/config/dc.js
@@ -6,6 +6,8 @@ module.exports = {
   CITY_NAME: 'NYC',
   BIKESHARE_NAME: 'Capital Bikeshare',
   BIKESHARE_NAME_PLURAL: 'Capital Bikeshares',
+  BIKESHARE_BIKE_NAME: 'Capital Bikeshare bike',
+  BIKESHARE_BIKE_NAME_PLURAL: 'Capital Bikeshare bikes',
   BIKESHARE_DATA_URL: 'https://www.capitalbikeshare.com/system-data',
-  AUTHOR: "<a href='https://twitter.com/alizauf'>Aliza Aufrichtig</a> & <a href='https://twitter.com/schep_'>Daniel Schep</a>",
+  AUTHOR: "<a style='color: #0498e4; text-decoration: none;' href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>, and remixed by <a style='color: #0498e4; text-decoration: none;' href='https://twitter.com/schep_'>Daniel Schep</a> for DC. See original at <a style='color: #0498e4; text-decoration: none;' href='https://www.i-want-to-ride-an-electric-citi.bike'>i-want-to-ride-an-electric-citi.bike",
 }

--- a/config/nyc.js
+++ b/config/nyc.js
@@ -4,8 +4,10 @@ module.exports = {
   MAP_CENTER: "[40.7055585, -73.989109 ]",
   MAP_ZOOM: 13,
   CITY_NAME: 'DC',
-  BIKESHARE_NAME: 'Citi Bikes',
+  BIKESHARE_NAME: 'Citi Bike',
   BIKESHARE_NAME_PLURAL: 'Citi Bikes',
+  BIKESHARE_BIKE_NAME: 'Citi Bike',
+  BIKESHARE_BIKE_NAME_PLURAL: 'Citi Bikes',
   BIKESHARE_DATA_URL: 'https://www.citibikenyc.com/system-data',
-  AUTHOR: "<a href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>",
+  AUTHOR: "<a style='color: #0498e4; text-decoration: none;' href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>",
 }

--- a/config/nyc.js
+++ b/config/nyc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  STATION_STATUS_GBFS: "'https://gbfs.citibikenyc.com/gbfs/en/station_status.json'",
+  STATION_INFORMATION_GBFS: "'https://gbfs.citibikenyc.com/gbfs/en/station_information.json'",
+  MAP_CENTER: "[40.7055585, -73.989109 ]",
+  MAP_ZOOM: 13,
+  CITY_NAME: 'DC',
+  BIKESHARE_NAME: 'Citi Bikes',
+  BIKESHARE_NAME_PLURAL: 'Citi Bikes',
+  BIKESHARE_DATA_URL: 'https://www.citibikenyc.com/system-data',
+  AUTHOR: "<a href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>",
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>Find an electric Bikeshare</title>
+		<title>Find an electric bike share bike</title>
 		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" />
 		<link href="https://fonts.googleapis.com/css?family=Overpass" rel="stylesheet">
 		<script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>Find an electric Citi Bike</title>
+		<title>Find an electric Bikeshare</title>
 		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" />
 		<link href="https://fonts.googleapis.com/css?family=Overpass" rel="stylesheet">
 		<script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-globals": "^1.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-serve": "^0.4.0",
     "rollup-plugin-svelte": "^4.1.0",
     "rollup-watch": "^3.2.2",

--- a/rollup-dev.config.js
+++ b/rollup-dev.config.js
@@ -3,8 +3,10 @@ import resolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import globals from "rollup-plugin-node-globals";
 import babel from "rollup-plugin-babel";
-import serve from 'rollup-plugin-serve'
+import serve from 'rollup-plugin-serve';
+import replace from 'rollup-plugin-replace';
 
+const config = require(process.env.CONFIG || './nyc.js')
 
 export default {
 	entry: 'main.js',
@@ -20,12 +22,12 @@ export default {
     globals(),
     babel({
       exclude: "node_modules/**"
-  }),
-  serve({
-	  contentBase: '',
-	  host: 'localhost',
-	  port: 4321
-  })
+    }),
+    serve({
+      contentBase: '',
+      host: 'localhost',
+      port: 4321
+    }),
+    replace(config),
 	]
-
 };

--- a/rollup-dev.config.js
+++ b/rollup-dev.config.js
@@ -6,7 +6,7 @@ import babel from "rollup-plugin-babel";
 import serve from 'rollup-plugin-serve';
 import replace from 'rollup-plugin-replace';
 
-const config = require(process.env.CONFIG || './nyc.js')
+const config = require(process.env.CONFIG || './config/nyc.js')
 
 export default {
 	entry: 'main.js',

--- a/rollup-production.config.js
+++ b/rollup-production.config.js
@@ -3,7 +3,9 @@ import resolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import globals from "rollup-plugin-node-globals";
 import babel from "rollup-plugin-babel";
+import replace from 'rollup-plugin-replace';
 
+const config = require(process.env.CONFIG || './config/nyc.js')
 
 export default {
 	entry: 'main.js',
@@ -19,7 +21,8 @@ export default {
     globals(),
     babel({
       exclude: "node_modules/**"
-  })
+    }),
+    replace(config),
 	]
 
 };

--- a/src/App.html
+++ b/src/App.html
@@ -3,12 +3,12 @@
   <div id='controls-and-footer'>
     <section id='controls'>
 
-      <h1>Is there an electric Citi Bike near you?</h1>
+      <h1>Is there an electric BIKESHARE_NAME near you?</h1>
       {#if iOS}
-      <p class='explanation'>Quickly scan the map of NYC to find the ever-so-elusive Citi Bikes. <em>If one is near you, run, run like the wind!</em></p> 
+      <p class='explanation'>Quickly scan the map of CITY_NAME to find the ever-so-elusive BIKESHARE_NAME_PLURAL. <em>If one is near you, run, run like the wind!</em></p> 
       <p>Sadly, iPhones and iPads don't allow browser alerts. If you visit this site on your computer, this app is even more helpful: you can follow stations and receive alerts when a bike appears.</p>
       {:else}
-      <p class='explanation'>Be the first to know when an elusive electric Citi Bike docks at any station near you. <em>Then, run, run like the wind!</em></p>
+      <p class='explanation'>Be the first to know when an elusive electric BIKESHARE_NAME docks at any station near you. <em>Then, run, run like the wind!</em></p>
 
       {/if}
 
@@ -22,7 +22,7 @@
             </div>
           {/each}
         {:else}
-          <p>Find Citi Bike stations near you on the map. <strong>Click on stations</strong> <span class='station-key'>●</span> to add them to your watch list. When an electric bike <span class='station-with-bike-key'>●</span> appears at any of your stations, you'll get an alert within 10 seconds. Then it's on you to get yourself electrified.</p>
+          <p>Find BIKESHARE_NAME stations near you on the map. <strong>Click on stations</strong> <span class='station-key'>●</span> to add them to your watch list. When an electric bike <span class='station-with-bike-key'>●</span> appears at any of your stations, you'll get an alert within 10 seconds. Then it's on you to get yourself electrified.</p>
         {/if}
 
 
@@ -65,9 +65,9 @@
       <p class='datetime'>Last updated {lastUpdated ? lastUpdated.toString().slice(0,24): "Loading..."}</p>
     </section>
     <footer> 
-      <p>By <a href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>, who has yet to ride an electric Citi Bike and considered not sharing this to have all the electric Citi Bikes, but it is a bike share after all.</p>
+      <p>By AUTHOR, who has yet to ride an electric BIKESHARE_NAME and considered not sharing this to have all the electric BIKESHARE_NAME_PLURAL, but it is a bike share after all.</p>
 
-      <p>Powered by <a href="https://www.citibikenyc.com/system-data">Citi Bike's Real-Time Data</a> and inspired by Citi Bike's real fun bike system. It is not affiliated with, approved by, endorsed by, or sponsored by Citi Bike. <a href='https://github.com/alizauf/the-bike-electric'>View the code here</a>. Lightning bolt favicon remixed from Nick Abrams's icon from the Noun Project. </p>
+      <p>Powered by <a href="BIKESHARE_DATA_URL">BIKESHARE_NAME's Real-Time Data</a> and inspired by BIKESHARE_NAME's real fun bike system. It is not affiliated with, approved by, endorsed by, or sponsored by BIKESHARE_NAME. <a href='https://github.com/alizauf/the-bike-electric'>View the code here</a>. Lightning bolt favicon remixed from Nick Abrams's icon from the Noun Project. </p>
 
       <p class='bike-electric'>
         <em>I sing the bike electric, <br />
@@ -297,7 +297,7 @@ export default {
     
     this.drawMap();
     
-    fetch("https://gbfs.citibikenyc.com/gbfs/en/station_information.json")
+    fetch(STATION_INFORMATION_GBFS)
     .then( res => res.json())
     .then( response => {
       const stations = response.data.stations; 
@@ -352,17 +352,17 @@ export default {
   
   methods: {
     centerMapOnStation(id) {
-      const { station_lookup, nyc_map } = this.get();
+      const { station_lookup, map } = this.get();
       const station  = station_lookup[id];
-      nyc_map.flyTo(new L.LatLng(station.lat, station.lon), 15);
+      map.flyTo(new L.LatLng(station.lat, station.lon), 15);
     },
 
     drawMap() {
-      const nyc_map = L.map('map').setView([40.7055585, -73.989109 ], 13);
-      this.set({nyc_map});
+      const map = L.map('map').setView(MAP_CENTER, MAP_ZOOM);
+      this.set({map});
       L.tileLayer( 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
         attribution: '&copy; <a id="home-link" target="_top" href="../">Map tiles</a> by <a target="_top" href="http://stamen.com">Stamen Design</a>, under <a target="_top" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'
-      }).addTo( nyc_map );
+      }).addTo( map );
     },
 
     circleClick(e) {
@@ -407,7 +407,7 @@ export default {
     },
     
     checkForEBikes () {
-      fetch('https://gbfs.citibikenyc.com/gbfs/en/station_status.json')
+      fetch(STATION_STATUS_GBFS)
       .then( res => res.json())
       .then( response => {
         const station_data = response.data.stations;
@@ -427,7 +427,7 @@ export default {
     drawStations() {
       
       const group = L.featureGroup();
-      const { stations, nyc_map, watched_stations, num_ebikes, stations_with_ebikes } = this.get();
+      const { stations, map, watched_stations, num_ebikes, stations_with_ebikes } = this.get();
       
       stations.forEach( station => {
         if (stations_with_ebikes.map( x => x.station_id).includes(station.station_id) ) {
@@ -461,11 +461,11 @@ export default {
 
       const { prevGroup } = this.get();
       if ( prevGroup ){
-        nyc_map.removeLayer(prevGroup);
+        map.removeLayer(prevGroup);
       }
       this.set({prevGroup: group});
       
-      nyc_map.addLayer(group);
+      map.addLayer(group);
     }
   } 
 };

--- a/src/App.html
+++ b/src/App.html
@@ -3,12 +3,12 @@
   <div id='controls-and-footer'>
     <section id='controls'>
 
-      <h1>Is there an electric BIKESHARE_NAME near you?</h1>
+      <h1>Is there an electric BIKESHARE_BIKE_NAME near you?</h1>
       {#if iOS}
       <p class='explanation'>Quickly scan the map of CITY_NAME to find the ever-so-elusive BIKESHARE_NAME_PLURAL. <em>If one is near you, run, run like the wind!</em></p> 
       <p>Sadly, iPhones and iPads don't allow browser alerts. If you visit this site on your computer, this app is even more helpful: you can follow stations and receive alerts when a bike appears.</p>
       {:else}
-      <p class='explanation'>Be the first to know when an elusive electric BIKESHARE_NAME docks at any station near you. <em>Then, run, run like the wind!</em></p>
+      <p class='explanation'>Be the first to know when an elusive electric BIKESHARE_BIKE_NAME docks at any station near you. <em>Then, run, run like the wind!</em></p>
 
       {/if}
 
@@ -65,7 +65,7 @@
       <p class='datetime'>Last updated {lastUpdated ? lastUpdated.toString().slice(0,24): "Loading..."}</p>
     </section>
     <footer> 
-      <p>By AUTHOR, who has yet to ride an electric BIKESHARE_NAME and considered not sharing this to have all the electric BIKESHARE_NAME_PLURAL, but it is a bike share after all.</p>
+      <p>By AUTHOR.</p>
 
       <p>Powered by <a href="BIKESHARE_DATA_URL">BIKESHARE_NAME's Real-Time Data</a> and inspired by BIKESHARE_NAME's real fun bike system. It is not affiliated with, approved by, endorsed by, or sponsored by BIKESHARE_NAME. <a href='https://github.com/alizauf/the-bike-electric'>View the code here</a>. Lightning bolt favicon remixed from Nick Abrams's icon from the Noun Project. </p>
 
@@ -471,4 +471,3 @@ export default {
 };
 
 </script>
-


### PR DESCRIPTION
Hey Aliza, I love this project!! I'm in DC and have been meaning to build something similar so when I saw this and saw it was open source, I was super stoked. Due to the ubiquity of GBFS, it was super easy to adapt this for use in any city that has a bikeshare operator with a GBFS feed.

This replaces all hard coded references to NYC, Citi Bike and their API
& documentation URLs with placeholders and uses the rollup replace
plugin to populate them

It still defaults to NYC/Citi, but I've included a configuration for
DC's Capital Bikeshare Plus.

To load a different city config, like DC, you run it like this:
```
CONFIG=./config/dc npm run dev
```

I've hosted the DC/CaBiPlus version on Glitch at
https://the-cabi-electric.glitch.me

I also made a few other minor changes:
 * removed the repository from `.npmrc` as it doesn't work for me
 * added `bundle.js` to the git ignore file