### PR TITLE
Make the project remixable on glitch & add locate control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ The app is written using [Svelte](https://github.com/sveltejs/svelte), [Leaflet]
 [Daniel Schep](https://www.twitter.com/schep_) updated the bike electric to work more easily with any
 bikeshare operator with electric bikes that provides [GBFS](https://github.com/NABSA/gbfs) feeds.
 
+The DC version is hosted on glitch and you can remix it for your own city.
+
+[![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/the-cabi-electric)
+
 See `config/nyc.js` and `config/dc.js` for examples of how to configure the bike electric for different cities.
-Create your own config at `config/CITYNAME.js` and run locally with: 
-```
-npm install
-CONFIG=./config/CITYNAME.js npm run dev
-```
-And compile a production version with:
-```
-CONFIG=./config/CITYNAME.js npm run build
+Create your own config at `config/CITYNAME.js` and update `.env` to contain:
+```shell
+CONFIG=./config/CITYNAME.js
 ```

--- a/config/sf.js
+++ b/config/sf.js
@@ -1,0 +1,13 @@
+module.exports = {
+  STATION_STATUS_GBFS: "'https://gbfs.fordgobike.com/gbfs/en/station_status.json'",
+  STATION_INFORMATION_GBFS: "'https://gbfs.fordgobike.com/gbfs/en/station_information.json'",
+  MAP_CENTER: "[ 37.7786982,-122.4152072 ]",
+  MAP_ZOOM: 13,
+  CITY_NAME: 'San Francisco',
+  BIKESHARE_NAME: 'Ford GoBike',
+  BIKESHARE_NAME_PLURAL: 'Ford GoBikes',
+  BIKESHARE_BIKE_NAME: 'Ford GoBike',
+  BIKESHARE_BIKE_NAME_PLURAL: 'Ford GoBikes',
+  BIKESHARE_DATA_URL: 'https://www.fordgobike.com/system-data',
+  AUTHOR: "<a style='color: #0498e4; text-decoration: none;' href='https://twitter.com/alizauf'>Aliza Aufrichtig</a>, and remixed by <a style='color: #0498e4; text-decoration: none;' href='https://twitter.com/schep_'>Daniel Schep</a> for SF. See original at <a style='color: #0498e4; text-decoration: none;' href='https://www.i-want-to-ride-an-electric-citi.bike'>i-want-to-ride-an-electric-citi.bike",
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
 		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" />
 		<link href="https://fonts.googleapis.com/css?family=Overpass" rel="stylesheet">
 		<script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css" />
+
+<script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.js" charset="utf-8"></script>
+
 
 <style>
 	body {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "svelte": "^2.6.1"
   },
   "scripts": {
+    "start": "npm run dev",
     "build": "rollup -c rollup-production.config.js",
     "dev": "rollup -c rollup-dev.config.js -w"
   }

--- a/rollup-dev.config.js
+++ b/rollup-dev.config.js
@@ -26,7 +26,7 @@ export default {
     serve({
       contentBase: '',
       host: 'localhost',
-      port: 4321
+      port: process.env.PORT || 4321
     }),
     replace(config),
 	]

--- a/src/App.html
+++ b/src/App.html
@@ -359,6 +359,7 @@ export default {
 
     drawMap() {
       const map = L.map('map').setView(MAP_CENTER, MAP_ZOOM);
+      L.control.locate().addTo(map);
       this.set({map});
       L.tileLayer( 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
         attribution: '&copy; <a id="home-link" target="_top" href="../">Map tiles</a> by <a target="_top" href="http://stamen.com">Stamen Design</a>, under <a target="_top" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'

--- a/src/App.html
+++ b/src/App.html
@@ -67,7 +67,7 @@
     <footer> 
       <p>By AUTHOR.</p>
 
-      <p>Powered by <a href="BIKESHARE_DATA_URL">BIKESHARE_NAME's Real-Time Data</a> and inspired by BIKESHARE_NAME's real fun bike system. It is not affiliated with, approved by, endorsed by, or sponsored by BIKESHARE_NAME. <a href='https://github.com/alizauf/the-bike-electric'>View the code here</a>. Lightning bolt favicon remixed from Nick Abrams's icon from the Noun Project. </p>
+      <p>Powered by <a href="BIKESHARE_DATA_URL">BIKESHARE_NAME's Real-Time Data</a> and inspired by BIKESHARE_NAME's real fun bike system. It is not affiliated with, approved by, endorsed by, or sponsored by BIKESHARE_NAME. <a href='https://github.com/alizauf/the-bike-electric'>View the code here</a> or <a href="https://glitch.com/edit/#!/remix/the-cabi-electric">Remix for your own city on Glitch</a>. Lightning bolt favicon remixed from Nick Abrams's icon from the Noun Project. </p>
 
       <p class='bike-electric'>
         <em>I sing the bike electric, <br />


### PR DESCRIPTION
These changes make it possible for people to simply remix the Glitch app for the DC version. Like that people can make a version for their city if they get an e-bikeshare without even having dev tools on their computer!

 * add an `npm start` command that serves the app
 * dev config now reads `process.env.PORT` and uses that if it set
 * update readme to instruct how to remix instead of running locally
 * add remix link next to source link in app.

And, I also added [domoritz/leaflet-locatecontrol](https://github.com/domoritz/leaflet-locatecontrol) to make it easier to find the bikeshare stations near you.